### PR TITLE
Zennでついた「いいね」数を表示、APIから受け取る値の変換

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/react-html-parser": "^2.0.2",
         "@types/react-modal": "^3.16.3",
         "axios": "^1.6.8",
+        "camelcase-keys": "^9.1.3",
         "date-fns": "^2.29.1",
         "framer-motion": "^11.0.25",
         "html-react-parser": "^3.0.1",
@@ -902,6 +903,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-9.1.3.tgz",
+      "integrity": "sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==",
+      "dependencies": {
+        "camelcase": "^8.0.0",
+        "map-obj": "5.0.0",
+        "quick-lru": "^6.1.1",
+        "type-fest": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2853,6 +2893,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/map-obj": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.0.tgz",
+      "integrity": "sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3552,6 +3603,17 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react-html-parser": "^2.0.2",
     "@types/react-modal": "^3.16.3",
     "axios": "^1.6.8",
+    "camelcase-keys": "^9.1.3",
     "date-fns": "^2.29.1",
     "framer-motion": "^11.0.25",
     "html-react-parser": "^3.0.1",

--- a/src/app/api/zenn/route.ts
+++ b/src/app/api/zenn/route.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import camelcaseKeys from 'camelcase-keys'
 import { NextResponse } from 'next/server'
 
 export async function GET() {
@@ -10,7 +11,9 @@ export async function GET() {
       },
     })
 
-    return NextResponse.json(response.data)
+    const data = camelcaseKeys(response.data, { deep: true })
+
+    return NextResponse.json(data)
   } catch (error) {
     console.error('Error fetching Zenn articles:', error)
     return NextResponse.json(

--- a/src/app/blog/Blog.tsx
+++ b/src/app/blog/Blog.tsx
@@ -4,20 +4,12 @@ import useSWR from 'swr'
 
 import BlogList from '@/components/BlogList/BlogList'
 import Hero from '@/components/Hero/Hero'
-
-interface Post {
-  id: number
-  path: string
-  title: string
-  published_at: string
-  body_updated_at?: string
-}
+import { Zenn } from '@/types/zenn'
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
 const Blog = () => {
-  const { data, error } = useSWR<{ articles: Post[] }>('/api/zenn', fetcher)
-
+  const { data, error } = useSWR<{ articles: Zenn[] }>('/api/zenn', fetcher)
   if (error) return <div>Failed to load blog posts.</div>
   if (!data) return null
 

--- a/src/components/BlogList/BlogList.tsx
+++ b/src/components/BlogList/BlogList.tsx
@@ -1,41 +1,41 @@
 import Link from 'next/link'
 
+import { Zenn } from '@/types/zenn'
+
 import ConvertDate from '../ConvertDate/ConvertDate'
 import styles from './BlogList.module.css'
 
-interface Props {
-  posts: {
-    id: number
-    path: string
-    title: string
-    published_at: string
-    body_updated_at?: string
-  }[]
+type Props = {
+  posts: Zenn[]
 }
 
 export default function BlogList({ posts }: Props) {
   return (
     <ul className={styles.list}>
-      {posts.map((post) => (
-        <li key={post.id}>
-          <Link
-            href={`https://zenn.dev/${post.path}`}
-            target="blank"
-            className={styles.link}>
-            <h2 className={styles.title}>{post.title}</h2>
-            <p>
-              投稿日：
-              <ConvertDate dateISO={post.published_at} />
-            </p>
-            {post.body_updated_at && (
+      {posts.map((post) => {
+        const { id, path, title, publishedAt, bodyUpdatedAt, likedCount } = post
+        return (
+          <li key={id}>
+            <Link
+              href={`https://zenn.dev/${path}`}
+              target="blank"
+              className={styles.link}>
+              <h2 className={styles.title}>{title}</h2>
               <p>
-                更新日：
-                <ConvertDate dateISO={post.body_updated_at} />
+                投稿日：
+                <ConvertDate dateISO={publishedAt} />
               </p>
-            )}
-          </Link>
-        </li>
-      ))}
+              {bodyUpdatedAt && (
+                <p>
+                  更新日：
+                  <ConvertDate dateISO={bodyUpdatedAt} />
+                </p>
+              )}
+              <p>いいね：{likedCount}</p>
+            </Link>
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/src/lib/microCMS/client.ts
+++ b/src/lib/microCMS/client.ts
@@ -1,7 +1,6 @@
+import camelcaseKeys from 'camelcase-keys'
 import { createClient } from 'microcms-js-sdk'
 import { NextResponse } from 'next/server'
-
-import { WorkApiResponse } from '@/types/work'
 
 export const client = createClient({
   serviceDomain: process.env.MICROCMS_SERVICE_DOMAIN as string,
@@ -14,7 +13,7 @@ export const getWorkDetailsBySlug = async (id: string) => {
       endpoint: `work/${id}`,
     })
 
-    const data = { ...res, thumbPc: res.thumb_pc, thumbSp: res.thumb_sp }
+    const data = camelcaseKeys(res, { deep: true })
 
     return data
   } catch (error: any) {

--- a/src/types/zenn.ts
+++ b/src/types/zenn.ts
@@ -1,0 +1,8 @@
+export interface Zenn {
+  id: number
+  path: string
+  title: string
+  publishedAt: string
+  bodyUpdatedAt?: string
+  likedCount: number
+}


### PR DESCRIPTION
Zennでついた「いいね」数を取得/表示できるように変更
BlogページとWorkページでApiから取得した際にをスネークケースからキャメルケースに変換するように変更 ※'camelcase-keys'を利用

Zenn APIの型をtypesディレクトリにzenn.tsというファイルで作成